### PR TITLE
Conntrack clover

### DIFF
--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Chat.Managers;
+using Content.Server.Connection;
 using Content.Server.Database;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -26,6 +26,7 @@ namespace Content.Server.Administration.Managers;
 
 public sealed partial class BanManager : IBanManager, IPostInjectInit
 {
+    [Dependency] private readonly IConnectionManager _connectionManager = default!; // Starlight
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IServerDbManager _db = default!;
@@ -72,7 +73,9 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         var netChannel = player.Channel;
         ImmutableArray<byte>? hwId = netChannel.UserData.HWId.Length == 0 ? null : netChannel.UserData.HWId;
         var modernHwids = netChannel.UserData.ModernHWIds;
-        var roleBans = await _db.GetServerRoleBansAsync(netChannel.RemoteEndPoint.Address, player.UserId, hwId, modernHwids, false);
+        var addr = _connectionManager.GetResolvedAddress(player.UserId)
+                   ?? netChannel.RemoteEndPoint.Address; // Starlight: prefer resolved IP
+        var roleBans = await _db.GetServerRoleBansAsync(addr, player.UserId, hwId, modernHwids, false);
 
         var userRoleBans = new List<ServerRoleBanDef>();
         foreach (var ban in roleBans)
@@ -189,7 +192,8 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         var playerInfo = new BanMatcher.PlayerInfo
         {
             UserId = player.UserId,
-            Address = player.Channel.RemoteEndPoint.Address,
+            Address = _connectionManager.GetResolvedAddress(player.UserId)
+                      ?? player.Channel.RemoteEndPoint.Address, // Starlight: prefer resolved IP
             HWId = player.Channel.UserData.HWId,
             ModernHWIds = player.Channel.UserData.ModernHWIds,
             // It's possible for the player to not have cached data loading yet due to coincidental timing.

--- a/Content.Server/Administration/PlayerLocator.cs
+++ b/Content.Server/Administration/PlayerLocator.cs
@@ -76,6 +76,7 @@ namespace Content.Server.Administration
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly IServerDbManager _db = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IConnectionManager _connectionManager = default!; // Starlight
 
         private readonly HttpClient _httpClient = new();
         private ISawmill _sawmill = default!;
@@ -148,10 +149,11 @@ namespace Content.Server.Administration
             return new LocatedPlayerData(new NetUserId(responseData.UserId), null, null, responseData.UserName, null, []);
         }
 
-        private static LocatedPlayerData ReturnForSession(ICommonSession session)
+        private LocatedPlayerData ReturnForSession(ICommonSession session) // Starlight: non-static, uses resolved IP
         {
             var userId = session.UserId;
-            var address = session.Channel.RemoteEndPoint.Address;
+            var address = _connectionManager.GetResolvedAddress(userId)
+                          ?? session.Channel.RemoteEndPoint.Address; // Starlight: prefer resolved IP
             var hwId = session.Channel.UserData.GetModernHwid();
             return new LocatedPlayerData(
                 userId,

--- a/Content.Server/Administration/PlayerPanelEui.cs
+++ b/Content.Server/Administration/PlayerPanelEui.cs
@@ -3,6 +3,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Administration.Notes;
 using Content.Server.Administration.Systems;
+using Content.Server.Connection;
 using Content.Server.Database;
 using Content.Server.EUI;
 using Content.Shared.Administration;
@@ -17,6 +18,7 @@ namespace Content.Server.Administration;
 public sealed class PlayerPanelEui : BaseEui
 {
     [Dependency] private readonly IAdminManager _admins = default!;
+    [Dependency] private readonly IConnectionManager _connectionManager = default!; // Starlight
     [Dependency] private readonly IServerDbManager _db = default!;
     [Dependency] private readonly IAdminNotesManager _notesMan = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
@@ -179,7 +181,10 @@ public sealed class PlayerPanelEui : BaseEui
             _notes = null;
         }
 
-        _sharedConnections = _player.Sessions.Count(s => s.Channel.RemoteEndPoint.Address.Equals(_targetPlayer.LastAddress) && s.UserId != _targetPlayer.UserId);
+        _sharedConnections = _player.Sessions.Count(s =>
+            (_connectionManager.GetResolvedAddress(s.UserId) ?? s.Channel.RemoteEndPoint.Address) // Starlight: prefer resolved IP
+                .Equals(_targetPlayer.LastAddress)
+            && s.UserId != _targetPlayer.UserId);
 
     // Apparently the Bans flag is also used for whitelists
     if (_admins.HasAdminFlag(Player, AdminFlags.Ban))

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -44,6 +44,13 @@ namespace Content.Server.Connection
         void AddTemporaryConnectBypass(NetUserId user, TimeSpan duration);
 
         void Update();
+
+        /// <summary>
+        /// Gets the resolved real client IP for a connected user.
+        /// When conntrack resolution is active, this returns the real IP behind SNAT.
+        /// Returns <c>null</c> if the user has no cached address.
+        /// </summary>
+        IPAddress? GetResolvedAddress(NetUserId user); // Starlight
     }
 
     /// <summary>
@@ -69,6 +76,7 @@ namespace Content.Server.Connection
 
         private ISawmill _sawmill = default!;
         private readonly Dictionary<NetUserId, TimeSpan> _temporaryBypasses = [];
+        private readonly Dictionary<NetUserId, IPAddress> _resolvedAddresses = []; // Starlight
         private IPIntel.IPIntel _ipintel = default!;
         private ConntrackResolver _conntrack = default!; // Starlight
 
@@ -97,6 +105,12 @@ namespace Content.Server.Connection
             // Make sure we only update the time if we wouldn't shrink it.
             if (newTime > time)
                 time = newTime;
+        }
+
+        // Starlight: resolved IP cache
+        public IPAddress? GetResolvedAddress(NetUserId user)
+        {
+            return _resolvedAddresses.GetValueOrDefault(user);
         }
 
         public async void Update()
@@ -161,6 +175,7 @@ namespace Content.Server.Connection
             }
             else
             {
+                _resolvedAddresses[userId] = addr; // Starlight: cache resolved IP for later lookups
                 await _db.AddConnectionLogAsync(userId, e.UserName, addr, hwid, trust, null, serverId);
 
                 if (!ServerPreferencesManager.ShouldStorePrefs(e.AuthType))
@@ -176,6 +191,8 @@ namespace Content.Server.Connection
             {
                 AdminAlertIfSharedConnection(args.Session);
             }
+            else if (args.NewStatus == SessionStatus.Disconnected) // Starlight
+                _resolvedAddresses.Remove(args.Session.UserId); // Starlight
         }
 
         private void AdminAlertIfSharedConnection(ICommonSession newSession)
@@ -184,11 +201,13 @@ namespace Content.Server.Connection
             if (playerThreshold < 0)
                 return;
 
-            var addr = newSession.Channel.RemoteEndPoint.Address;
+            var addr = _resolvedAddresses.GetValueOrDefault(newSession.UserId)
+                       ?? newSession.Channel.RemoteEndPoint.Address; // Starlight: use resolved IP
 
             var otherConnectionsFromAddress = _plyMgr.Sessions.Where(session =>
                     session.Status is SessionStatus.Connected or SessionStatus.InGame
-                    && session.Channel.RemoteEndPoint.Address.Equals(addr)
+                    && (_resolvedAddresses.GetValueOrDefault(session.UserId)
+                        ?? session.Channel.RemoteEndPoint.Address).Equals(addr) // Starlight: use resolved IP
                     && session.UserId != newSession.UserId)
                 .ToList();
 

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using Content.Server.Administration.Managers;
@@ -69,6 +70,7 @@ namespace Content.Server.Connection
         private ISawmill _sawmill = default!;
         private readonly Dictionary<NetUserId, TimeSpan> _temporaryBypasses = [];
         private IPIntel.IPIntel _ipintel = default!;
+        private ConntrackResolver _conntrack = default!; // Starlight
 
         public void PostInit()
         {
@@ -132,9 +134,10 @@ namespace Content.Server.Connection
 
         private async Task NetMgrOnConnecting(NetConnectingArgs e)
         {
-            var deny = await ShouldDeny(e);
+            // Starlight: resolve real client IP via conntrack-agent (SNAT bypass)
+            var addr = await _conntrack.ResolveRealIp(e.IP) ?? e.IP.Address;
 
-            var addr = e.IP.Address;
+            var deny = await ShouldDeny(e, addr); // Starlight
             var userId = e.UserId;
 
             var serverId = (await _serverDbEntry.ServerEntity).Id;
@@ -208,10 +211,9 @@ namespace Content.Server.Connection
          * TODO: Break this apart into is constituent steps.
          */
         private async Task<(ConnectionDenyReason, string, List<ServerBanDef>? bansHit)?> ShouldDeny(
-            NetConnectingArgs e)
+            NetConnectingArgs e, IPAddress addr) // Starlight: accept resolved IP
         {
             // Check if banned.
-            var addr = e.IP.Address;
             var userId = e.UserId;
             ImmutableArray<byte>? hwId = e.UserData.HWId;
             if (hwId.Value.Length == 0 || !_cfg.GetCVar(CCVars.BanHardwareIds))
@@ -341,7 +343,7 @@ namespace Content.Server.Connection
             // ALWAYS keep this at the end, to preserve the API limit.
             if (_cfg.GetCVar(CCVars.GameIPIntelEnabled) && adminData == null)
             {
-                var result = await _ipintel.IsVpnOrProxy(e);
+                var result = await _ipintel.IsVpnOrProxy(e, addr); // Starlight: pass resolved IP
 
                 if (result.IsBad)
                     return (ConnectionDenyReason.IPChecks, result.Reason, null);

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -19,6 +19,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Content.Server._Starlight.Connection;
 
 /*
  * TODO: Remove baby jail code once a more mature gateway process is established. This code is only being issued as a stopgap to help with potential tiding in the immediate future.

--- a/Content.Server/Connection/IPIntel/IPIntel.cs
+++ b/Content.Server/Connection/IPIntel/IPIntel.cs
@@ -87,7 +87,7 @@ public sealed class IPIntel
     private float _rating;
     private float _alertAdminWarn;
 
-    public async Task<(bool IsBad, string Reason)> IsVpnOrProxy(NetConnectingArgs e)
+    public async Task<(bool IsBad, string Reason)> IsVpnOrProxy(NetConnectingArgs e, IPAddress? resolvedIp = null) // Starlight: accept resolved IP
     {
         // Check Exemption flags, let them skip if they have them.
         var flags = await _db.GetBanExemption(e.UserId);
@@ -107,7 +107,7 @@ public sealed class IPIntel
             }
         }
 
-        var ip = e.IP.Address;
+        var ip = resolvedIp ?? e.IP.Address; // Starlight: use resolved IP if available
         var username = e.UserName;
 
         // Is this a local ip address?

--- a/Content.Server/_Starlight/Connection/ConntrackResolver.cs
+++ b/Content.Server/_Starlight/Connection/ConntrackResolver.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Content.Shared.Starlight.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Network;
+
+namespace Content.Server._Starlight.Connection;
+
+/// <summary>
+/// Resolves the real client IP via a conntrack-agent running on the Kubernetes node.
+/// When kube-proxy performs SNAT (NodePort), the game server sees the node IP instead
+/// of the real client IP. The conntrack-agent queries the kernel conntrack table using
+/// the masquerade source port and returns the original client IP.
+/// Each Kubernetes node runs a conntrack-agent on the same port. The resolver checks
+/// whether the source IP falls within any of the configured node subnets and, if so,
+/// queries that node's agent at <c>http://{srcIp}:{port}/conntrack?port={masqPort}</c>.
+/// Supports both IPv4 and IPv6 (dual-stack) subnets.
+/// </summary>
+public sealed class ConntrackResolver
+{
+    private readonly IHttpClientHolder _http;
+    private readonly ISawmill _sawmill;
+
+    private bool _enabled;
+    private int _port;
+    private List<(IPAddress Network, int PrefixLength)> _subnets = [];
+
+    public ConntrackResolver(IHttpClientHolder http, IConfigurationManager cfg, ILogManager logManager)
+    {
+        _http = http;
+        _sawmill = logManager.GetSawmill("conntrack");
+
+        cfg.OnValueChanged(StarlightCCVars.ConntrackEnabled, v => _enabled = v, true);
+        cfg.OnValueChanged(StarlightCCVars.ConntrackPort, v => _port = v, true);
+        cfg.OnValueChanged(StarlightCCVars.ConntrackSubnet, ParseSubnets, true);
+    }
+
+    private void ParseSubnets(string raw)
+    {
+        var list = new List<(IPAddress, int)>();
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            _subnets = list;
+            return;
+        }
+
+        foreach (var entry in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = entry.Split('/');
+            if (parts.Length != 2
+                || !IPAddress.TryParse(parts[0], out var network)
+                || !int.TryParse(parts[1], out var prefix)
+                || prefix < 0
+                || (network.AddressFamily == AddressFamily.InterNetwork && prefix > 32)
+                || (network.AddressFamily == AddressFamily.InterNetworkV6 && prefix > 128))
+            {
+                _sawmill.Warning("Ignoring invalid CIDR in conntrack.subnet: {Value}", entry);
+                continue;
+            }
+
+            list.Add((network, prefix));
+        }
+
+        _subnets = list;
+    }
+
+    private bool IsInAnySubnet(IPAddress address)
+    {
+        foreach (var (network, prefixLength) in _subnets)
+        {
+            if (IsInSubnet(address, network, prefixLength))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsInSubnet(IPAddress address, IPAddress network, int prefixLength)
+    {
+        var addr = address;
+
+        // Handle IPv4-mapped IPv6 (e.g. ::ffff:10.42.0.1) against IPv4 subnets.
+        if (addr.AddressFamily == AddressFamily.InterNetworkV6
+            && addr.IsIPv4MappedToIPv6
+            && network.AddressFamily == AddressFamily.InterNetwork)
+        {
+            addr = addr.MapToIPv4();
+        }
+
+        if (addr.AddressFamily != network.AddressFamily)
+            return false;
+
+        var addrBytes = addr.GetAddressBytes();
+        var netBytes = network.GetAddressBytes();
+        var fullBytes = prefixLength / 8;
+        var remainingBits = prefixLength % 8;
+
+        for (var i = 0; i < fullBytes; i++)
+        {
+            if (addrBytes[i] != netBytes[i])
+                return false;
+        }
+
+        if (remainingBits > 0)
+        {
+            var mask = (byte)(0xFF << (8 - remainingBits));
+            if ((addrBytes[fullBytes] & mask) != (netBytes[fullBytes] & mask))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static string FormatHostForUrl(IPAddress address) 
+        => address.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{address}]"
+            : address.ToString();
+
+    /// <summary>
+    /// Resolves the real client IP via the conntrack-agent.
+    /// If the source address falls within any configured node subnet, queries
+    /// <c>http://{srcIp}:{port}/conntrack?port={masqPort}</c> (with brackets for IPv6).
+    /// Returns the real IP if SNAT was detected, or <c>null</c> if no resolution was
+    /// needed (source is outside all subnets), the feature is disabled, or an error occurred.
+    /// </summary>
+    public async Task<IPAddress?> ResolveRealIp(IPEndPoint masqueradeEndpoint)
+    {
+        if (!_enabled || _subnets.Count == 0)
+            return null;
+
+        if (!IsInAnySubnet(masqueradeEndpoint.Address))
+            return null;
+
+        try
+        {
+            var host = FormatHostForUrl(masqueradeEndpoint.Address);
+            var url = $"http://{host}:{_port}/conntrack?port={masqueradeEndpoint.Port}";
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            using var response = await _http.Client.GetAsync(url, cts.Token);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _sawmill.Warning("Conntrack agent on {Node} returned HTTP {StatusCode}",
+                    masqueradeEndpoint.Address, response.StatusCode);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cts.Token);
+            var result = JsonSerializer.Deserialize<ConntrackResponse>(json);
+
+            if (result is null)
+            {
+                _sawmill.Warning("Conntrack agent on {Node} returned unparseable response",
+                    masqueradeEndpoint.Address);
+                return null;
+            }
+
+            if (result.Error is not null)
+            {
+                _sawmill.Warning("Conntrack agent on {Node} error: {Error}",
+                    masqueradeEndpoint.Address, result.Error);
+                return null;
+            }
+
+            if (result.Ip is null)
+            {
+                // No SNAT detected — use original IP as-is.
+                return null;
+            }
+
+            if (IPAddress.TryParse(result.Ip, out var realIp))
+            {
+                _sawmill.Verbose("Resolved real IP for masquerade port {Port} via node {Node}",
+                    masqueradeEndpoint.Port, masqueradeEndpoint.Address);
+                return realIp;
+            }
+
+            _sawmill.Warning("Conntrack agent on {Node} returned invalid IP format",
+                masqueradeEndpoint.Address);
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            _sawmill.Warning("Conntrack resolution timed out for port {Port} via node {Node}",
+                masqueradeEndpoint.Port, masqueradeEndpoint.Address);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _sawmill.Warning("Conntrack resolution via node {Node} failed: {Error}",
+                masqueradeEndpoint.Address, ex.Message);
+            return null;
+        }
+    }
+
+    private sealed class ConntrackResponse
+    {
+        [JsonPropertyName("ip")]
+        public string? Ip { get; set; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+    }
+}

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Conntrack.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Conntrack.cs
@@ -1,0 +1,30 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.Starlight.CCVar;
+
+public sealed partial class StarlightCCVars
+{
+    /// <summary>
+    /// Whether conntrack-based real IP resolution is enabled.
+    /// When running behind a NodePort kube-proxy with SNAT, the game server sees the node IP
+    /// instead of the real client IP. The conntrack-agent resolves the real IP from the kernel
+    /// conntrack table using the masquerade port.
+    /// </summary>
+    public static readonly CVarDef<bool> ConntrackEnabled =
+        CVarDef.Create("conntrack.enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Port on which the conntrack-agent HTTP service listens on every Kubernetes node (e.g. 9876).
+    /// </summary>
+    public static readonly CVarDef<int> ConntrackPort =
+        CVarDef.Create("conntrack.port", 9876, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Comma-separated list of Kubernetes node subnets in CIDR notation
+    /// (e.g. "10.42.0.0/16" or "10.42.0.0/16,fd42::/64" for dual-stack).
+    /// When a connection arrives from an IP within any of these subnets, SNAT is assumed
+    /// and the conntrack-agent on that node is queried to resolve the real client IP.
+    /// </summary>
+    public static readonly CVarDef<string> ConntrackSubnet =
+        CVarDef.Create("conntrack.subnet", "10.42.0.0/16", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+}


### PR DESCRIPTION
## Short description
After the move to Kubernetes, UDP packets are automatically routed from any node to the server. This is beneficial right up until we start banning by IP, because the incoming IP becomes the IP of the node that received the packet. This fix adds a request to fetch the real IP address at the start of the connection.
### LICENSE: MIT

## Why we need to add this


## Media (Video/Screenshots)
<!-- Required if it's a visual change, however small changes even if they're visual don't need it. Media Links here: -->


## Checks
<!-- These are all required -->
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed either under MIT, MPL or any other non-copyleft license.

